### PR TITLE
Add diagnostics utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# Demand Forecasting Experiments
 
+This repository contains prototypes for forecasting weekly orange juice sales.
+Most models live in `src/` and operate on `data/OrangeJuiceX25.csv`.
+
+## Diagnostics
+
+A helper script `src/diagnostics.py` performs several sanity checks:
+
+1. **Data leakage check** – runs a random GETS window and prints the first/last
+   training rows and the held-out test row.
+2. **Unified log re-transform** – `smearing_transform()` applies Duan's smearing
+   to log predictions.
+3. **Error heat-map** – computes per-series RMSE via GETS and prints a pivot
+   table of `store` vs `brand`.
+4. **Residual tests** – Ljung–Box and ARCH tests on GETS residuals.
+
+Run it with:
+
+```bash
+python src/diagnostics.py
+```
+
+The dataset and required Python packages (pandas, statsmodels, etc.) must be
+installed locally.

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import random
+import numpy as np
+import pandas as pd
+from statsmodels.stats.diagnostic import acorr_ljungbox, het_arch
+
+from econometric_models import load_processed, gets_per_series
+
+
+def check_data_leakage(df: pd.DataFrame) -> None:
+    """Run one random GETS window with debug printing."""
+    stores = df["store"].unique().tolist()
+    brands = df["brand"].unique().tolist()
+    store = random.choice(stores)
+    brand = random.choice(brands)
+    print(f"\nChecking data leakage for store={store}, brand={brand}")
+    gets_per_series(df, store, brand, debug=True)
+
+
+def smearing_transform(log_pred: np.ndarray, residuals: np.ndarray) -> np.ndarray:
+    """Apply a unified log→level transform using Duan's smearing."""
+    smear = np.exp((residuals ** 2).mean() / 2)
+    return np.exp(log_pred) * smear
+
+
+def error_heatmap(df: pd.DataFrame) -> pd.DataFrame:
+    """Pivot table of per-series RMSE using GETS."""
+    results = []
+    for s in sorted(df["store"].unique()):
+        for b in sorted(df["brand"].unique()):
+            try:
+                rmse = gets_per_series(df, s, b)
+                results.append({"store": s, "brand": b, "rmse": rmse})
+            except ValueError:
+                continue
+    pivot = (
+        pd.DataFrame(results)
+        .pivot(index="store", columns="brand", values="rmse")
+        .sort_index()
+    )
+    print("\nRMSE heat-map (store x brand):")
+    print(pivot)
+    return pivot
+
+
+def residual_tests(df: pd.DataFrame, store: int, brand: int) -> None:
+    """Ljung-Box and ARCH tests on GETS residuals."""
+    rmse, resid, _, _ = gets_per_series(
+        df, store, brand, return_residuals=True
+    )
+    print(f"\nGETS RMSE for store={store}, brand={brand}: {rmse:.2f}")
+    lb = acorr_ljungbox(resid, lags=[8], return_df=True)
+    arch = het_arch(resid, nlags=8)
+    print("Ljung-Box p-value:", lb["lb_pvalue"].iloc[0])
+    print("ARCH p-value:", arch[1])
+
+
+if __name__ == "__main__":
+    df_proc = load_processed()
+    check_data_leakage(df_proc)
+    error_heatmap(df_proc)
+    residual_tests(df_proc, df_proc["store"].iloc[0], df_proc["brand"].iloc[0])
+


### PR DESCRIPTION
## Summary
- create helper `diagnostics.py` for checking data leakage, unified retransform, heat-map, and residual tests
- extend `gets_per_series` with debug and residual output
- document diagnostics script in `README`

## Testing
- `python -m py_compile src/econometric_models.py src/diagnostics.py`

------
https://chatgpt.com/codex/tasks/task_b_683f6dc95934832ba0a2f97ad18a1a12